### PR TITLE
Add ms.lock functionality

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,9 +2,41 @@ package main
 
 import (
 	"os"
+  "os/signal"
 )
 
 func main() {
+	var test string
+	exitsig := make(chan os.Signal, 1)
+	signal.Notify(exitsig, os.Interrupt)
+	var (
+			lockstate bool = false
+	)
+
+	go func() {
+			<-exitsig
+			if lockstate {
+					var err = os.Remove("ms.lock")
+					if err != nil {
+							return
+					}
+			}
+			os.Exit(0)
+	}()
+
+	if _, err := os.Stat("ms.lock"); err == nil {
+			return
+
+	} else if os.IsNotExist(err) {
+			var file, err = os.Create("ms.lock")
+			if err != nil {
+					return
+			}
+			file.Close()
+			defer os.Remove("ms.lock")
+			lockstate = true
+	}
+	
 	if len(os.Args) > 1 {
 		if os.Args[1] == "newblock" {
 			newblock()

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
   	"os/signal"
+	"fmt"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -2,39 +2,39 @@ package main
 
 import (
 	"os"
-  "os/signal"
+  	"os/signal"
 )
 
 func main() {
-	var test string
 	exitsig := make(chan os.Signal, 1)
 	signal.Notify(exitsig, os.Interrupt)
-	var (
-			lockstate bool = false
-	)
+	lockstate := false
 
 	go func() {
-			<-exitsig
-			if lockstate {
-					var err = os.Remove("ms.lock")
-					if err != nil {
-							return
-					}
+		<-exitsig
+		if lockstate {
+			err := os.Remove("ms.lock")
+			if err != nil {
+				fmt.Printf("couldn't remove the lock: %v", err)
+				return
 			}
-			os.Exit(0)
+		}
+		os.Exit(0)
 	}()
 
 	if _, err := os.Stat("ms.lock"); err == nil {
-			return
+		fmt.Printf("Cannot run program : Another Instance already running")
+		return
 
 	} else if os.IsNotExist(err) {
-			var file, err = os.Create("ms.lock")
-			if err != nil {
-					return
-			}
-			file.Close()
-			defer os.Remove("ms.lock")
-			lockstate = true
+		var file, err = os.Create("ms.lock")
+		if err != nil {
+			fmt.Printf("couldn't create the lock: %v", err)
+			return
+		}
+		file.Close()
+		defer os.Remove("ms.lock")
+		lockstate = true
 	}
 	
 	if len(os.Args) > 1 {

--- a/tui.go
+++ b/tui.go
@@ -28,8 +28,8 @@ func newTui() *tui {
 }
 
 func removeLock() int {
-    defer os.Remove("ms.lock")
-    return 1
+        defer os.Remove("ms.lock")
+        return 1
 }
 
 func (tui *tui) addBlocks() {
@@ -229,7 +229,7 @@ func (tui *tui) init() {
 
 	if err := q.Load(); err != nil {
 		fmt.Println(err)
-		os.Exit(removeLock()
+		os.Exit(removeLock())
 	}
 
 	tui.queue = q

--- a/tui.go
+++ b/tui.go
@@ -27,6 +27,11 @@ func newTui() *tui {
 	}
 }
 
+func removeLock() int {
+    defer os.Remove("ms.lock")
+    return 1
+}
+
 func (tui *tui) addBlocks() {
 	// Queue
 	for i, block := range tui.queue {
@@ -215,7 +220,7 @@ func (tui *tui) run() {
 
 	if err := tui.queue.Save(); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		os.Exit(removeLock())
 	}
 }
 
@@ -224,7 +229,7 @@ func (tui *tui) init() {
 
 	if err := q.Load(); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		os.Exit(removeLock()
 	}
 
 	tui.queue = q


### PR DESCRIPTION
Made main.go remove the lock file for normal exits and signal interruption exits. 
Also made tui.go honor the defer when exiting via `os.exit()`

I still couldn't test it even with the `config-path` branch but I've tested this methodology with a basic program and it works.